### PR TITLE
fix: allow libsqlite3-sys >=0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ metrics = "0.24"
 
 # SQLite support (optional, bundled)
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "chrono"], optional = true }
-libsqlite3-sys = { version = "0.28", features = ["bundled"], optional = true }
+libsqlite3-sys = { version = ">=0.28", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 # Used in tests/examples


### PR DESCRIPTION
## Summary

First diagnosed in https://github.com/microsoft/duroxide-pg/issues/4.  The root issue is that `libsqlite3-sys was clamped to 0.28 but sqlx==0.8.6 requires libsqlite3-sys >= 0.30.

## Checklist

- [ ] Tests added/updated
- [x] `cargo test` passes locally
- [ ] Docs updated
  - [ ] Existing docs updated where behavior changed
  - [ ] New doc added under `docs/` if introducing a new area
  - [ ] Linked from `docs/README.md`

