### PR TITLE
Remove ring dependency path by switching SQLx to native-tls/OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ semver = "1"
 metrics = "0.24"
 
 # SQLite support (optional, bundled)
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "chrono"], optional = true }
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "sqlite", "macros", "migrate", "chrono"], optional = true }
 libsqlite3-sys = { version = ">=0.28", features = ["bundled"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- switch SQLx runtime feature from `runtime-tokio-rustls` to `runtime-tokio-native-tls`
- remove the transitive `ring` dependency path from this crate's dependency graph
- align Linux crypto backend usage with OpenSSL policy

## Why
`ring` is not FIPS compliant for our policy requirements. This change routes TLS through native-tls/OpenSSL, which is the approved cryptographic backend on Linux.

## Scope
- only `Cargo.toml` changed
- no functional runtime code changes

## Validation
- `cargo check --workspace --all-features` passes
- `cargo tree -i ring --workspace --all-features` reports no matching package
