### PR TITLE
[codex] Fix large fan-in replay joins

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 
 // Public orchestration primitives and executor
 
@@ -669,15 +669,20 @@ impl<T> Future for DurableFuture<T> {
         match self.inner.as_mut().poll(cx) {
             Poll::Ready(value) => {
                 self.completed = true;
+                self.ctx.clear_token_waker(self.token);
                 Poll::Ready(value)
             }
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                self.ctx.register_token_waker(self.token, cx.waker());
+                Poll::Pending
+            }
         }
     }
 }
 
 impl<T> Drop for DurableFuture<T> {
     fn drop(&mut self) {
+        self.ctx.clear_token_waker(self.token);
         if !self.completed {
             // Future dropped without completing - trigger cancellation.
             // Note: During dehydration (TurnResult::Continue), the orchestration future
@@ -1600,6 +1605,10 @@ struct CtxInner {
     completion_results: std::collections::HashMap<u64, CompletionResult>,
     /// Token -> schedule_id binding (set when replay engine matches action to history)
     token_bindings: std::collections::HashMap<u64, u64>,
+    /// Schedule_id -> token binding for O(1) completion delivery.
+    schedule_bindings: std::collections::HashMap<u64, u64>,
+    /// Last waker observed while each durable token was pending.
+    token_wakers: std::collections::HashMap<u64, Waker>,
     /// External subscriptions: schedule_id -> (name, subscription_index)
     external_subscriptions: std::collections::HashMap<u64, (String, usize)>,
     /// External arrivals: name -> list of payloads in arrival order
@@ -1682,6 +1691,8 @@ impl CtxInner {
             emitted_actions: Vec::new(),
             completion_results: Default::default(),
             token_bindings: Default::default(),
+            schedule_bindings: Default::default(),
+            token_wakers: Default::default(),
             external_subscriptions: Default::default(),
             external_arrivals: Default::default(),
             external_next_index: Default::default(),
@@ -1740,7 +1751,10 @@ impl CtxInner {
 
     /// Bind a token to a schedule_id (called by replay engine when matching action to history).
     fn bind_token(&mut self, token: u64, schedule_id: u64) {
-        self.token_bindings.insert(token, schedule_id);
+        if let Some(old_schedule_id) = self.token_bindings.insert(token, schedule_id) {
+            self.schedule_bindings.remove(&old_schedule_id);
+        }
+        self.schedule_bindings.insert(schedule_id, token);
     }
 
     /// Get the schedule_id bound to a token (returns None if not yet bound).
@@ -1749,23 +1763,35 @@ impl CtxInner {
     }
 
     /// Deliver a completion result for a schedule_id.
-    fn deliver_result(&mut self, schedule_id: u64, result: CompletionResult) {
-        // Find the token that was bound to this schedule_id
-        for (&token, &sid) in &self.token_bindings {
-            if sid == schedule_id {
-                self.completion_results.insert(token, result);
-                return;
-            }
+    fn deliver_result(&mut self, schedule_id: u64, result: CompletionResult) -> Option<Waker> {
+        if let Some(&token) = self.schedule_bindings.get(&schedule_id) {
+            self.completion_results.insert(token, result);
+            return self.token_wakers.remove(&token);
         }
         tracing::warn!(
             schedule_id,
             "dropping completion result with no binding (unsupported for now)"
         );
+        None
     }
 
     /// Check if a result is available for a token.
     fn get_result(&self, token: u64) -> Option<&CompletionResult> {
         self.completion_results.get(&token)
+    }
+
+    fn register_token_waker(&mut self, token: u64, waker: &Waker) {
+        match self.token_wakers.get_mut(&token) {
+            Some(existing) if existing.will_wake(waker) => {}
+            Some(existing) => *existing = waker.clone(),
+            None => {
+                self.token_wakers.insert(token, waker.clone());
+            }
+        }
+    }
+
+    fn clear_token_waker(&mut self, token: u64) {
+        self.token_wakers.remove(&token);
     }
 
     /// Bind an external subscription to a deterministic index.
@@ -2594,7 +2620,26 @@ impl OrchestrationContext {
     /// Deliver a result for a token.
     #[doc(hidden)]
     pub fn deliver_result(&self, schedule_id: u64, result: CompletionResult) {
-        self.inner.lock().unwrap().deliver_result(schedule_id, result);
+        let waker = self.inner.lock().unwrap().deliver_result(schedule_id, result);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn register_token_waker(&self, token: u64, waker: &Waker) {
+        self.inner
+            .lock()
+            .expect("Mutex should not be poisoned")
+            .register_token_waker(token, waker);
+    }
+
+    #[doc(hidden)]
+    pub fn clear_token_waker(&self, token: u64) {
+        self.inner
+            .lock()
+            .expect("Mutex should not be poisoned")
+            .clear_token_waker(token);
     }
 
     /// Returns the orchestration instance identifier.

--- a/src/runtime/replay_engine.rs
+++ b/src/runtime/replay_engine.rs
@@ -9,8 +9,11 @@ use std::collections::{HashSet, VecDeque};
 use std::future::Future;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::task::{Context, Poll, Wake, Waker};
 use tracing::{debug, warn};
 
 /// Result of executing an orchestration turn
@@ -576,6 +579,7 @@ impl ReplayEngine {
         let mut open_schedules: HashSet<u64> = HashSet::new();
         let mut schedule_kinds: std::collections::HashMap<u64, ActionKind> = std::collections::HashMap::new();
         let mut emitted_actions: VecDeque<(u64, Action)> = VecDeque::new();
+        let wake_state = Arc::new(ReplayWakeState::default());
 
         let mut must_poll = true;
         let mut output_opt: Option<Result<String, String>> = None;
@@ -605,7 +609,7 @@ impl ReplayEngine {
             }
 
             if must_poll {
-                match Self::poll_orchestration_future(&mut fut, &ctx, &mut emitted_actions) {
+                match Self::poll_orchestration_future(&mut fut, &ctx, &mut emitted_actions, &wake_state) {
                     Ok(Some(result)) => {
                         output_opt = Some(result);
                         break;
@@ -626,12 +630,15 @@ impl ReplayEngine {
             ) {
                 return err;
             }
+            if wake_state.is_woken() {
+                must_poll = true;
+            }
         }
 
         ctx.set_is_replaying(false);
 
         if must_poll && output_opt.is_none() {
-            match Self::poll_orchestration_future(&mut fut, &ctx, &mut emitted_actions) {
+            match Self::poll_orchestration_future(&mut fut, &ctx, &mut emitted_actions, &wake_state) {
                 Ok(Some(result)) => output_opt = Some(result),
                 Ok(None) => {}
                 Err(err) => return err,
@@ -647,7 +654,7 @@ impl ReplayEngine {
 
         self.convert_emitted_actions(&ctx, emitted_actions);
 
-        if let Err(err) = self.run_quiescence_loop(&ctx, &mut fut, &mut output_opt) {
+        if let Err(err) = self.run_quiescence_loop(&ctx, &mut fut, &mut output_opt, &wake_state) {
             return err;
         }
 
@@ -658,24 +665,36 @@ impl ReplayEngine {
         fut: &mut Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>,
         ctx: &OrchestrationContext,
         emitted_actions: &mut VecDeque<(u64, Action)>,
+        wake_state: &Arc<ReplayWakeState>,
     ) -> Result<Option<Result<String, String>>, TurnResult> {
-        let poll_result = catch_unwind(AssertUnwindSafe(|| poll_once(fut.as_mut())));
-        match poll_result {
-            Ok(Poll::Ready(result)) => {
-                emitted_actions.extend(ctx.drain_emitted_actions());
-                Ok(Some(result))
-            }
-            Ok(Poll::Pending) => {
-                emitted_actions.extend(ctx.drain_emitted_actions());
-                Ok(None)
-            }
-            Err(panic_payload) => {
-                let msg = extract_panic_message(panic_payload);
-                Err(TurnResult::Failed(crate::ErrorDetails::Application {
-                    kind: crate::AppErrorKind::Panicked,
-                    message: msg,
-                    retryable: false,
-                }))
+        let waker = Waker::from(Arc::clone(wake_state));
+
+        loop {
+            wake_state.take_woken();
+            let poll_result = catch_unwind(AssertUnwindSafe(|| poll_once(fut.as_mut(), &waker)));
+            match poll_result {
+                Ok(Poll::Ready(result)) => {
+                    emitted_actions.extend(ctx.drain_emitted_actions());
+                    return Ok(Some(result));
+                }
+                Ok(Poll::Pending) => {
+                    let drained = ctx.drain_emitted_actions();
+                    let emitted_new_actions = !drained.is_empty();
+                    emitted_actions.extend(drained);
+                    // If this poll emitted durable actions, replay must bind/validate them
+                    // against history before letting wake-driven progress run ahead.
+                    if emitted_new_actions || !wake_state.take_woken() {
+                        return Ok(None);
+                    }
+                }
+                Err(panic_payload) => {
+                    let msg = extract_panic_message(panic_payload);
+                    return Err(TurnResult::Failed(crate::ErrorDetails::Application {
+                        kind: crate::AppErrorKind::Panicked,
+                        message: msg,
+                        retryable: false,
+                    }));
+                }
             }
         }
     }
@@ -985,6 +1004,7 @@ impl ReplayEngine {
         ctx: &OrchestrationContext,
         fut: &mut Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>>,
         output_opt: &mut Option<Result<String, String>>,
+        wake_state: &Arc<ReplayWakeState>,
     ) -> Result<(), TurnResult> {
         const MAX_QUIESCENCE_ITERATIONS: usize = 100;
         let mut quiescence_iter = 0;
@@ -994,7 +1014,7 @@ impl ReplayEngine {
             quiescence_iter += 1;
             let actions_before = self.pending_actions.len();
 
-            if let Some(res) = Self::poll_orchestration_future(fut, ctx, &mut emitted_actions)? {
+            if let Some(res) = Self::poll_orchestration_future(fut, ctx, &mut emitted_actions, wake_state)? {
                 *output_opt = Some(res);
             }
             self.convert_emitted_actions(ctx, emitted_actions.drain(..));
@@ -1596,6 +1616,31 @@ impl ReplayEngine {
     }
 }
 
+#[derive(Debug, Default)]
+struct ReplayWakeState {
+    woken: AtomicBool,
+}
+
+impl ReplayWakeState {
+    fn is_woken(&self) -> bool {
+        self.woken.load(Ordering::SeqCst)
+    }
+
+    fn take_woken(&self) -> bool {
+        self.woken.swap(false, Ordering::SeqCst)
+    }
+}
+
+impl Wake for ReplayWakeState {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.woken.store(true, Ordering::SeqCst);
+    }
+}
+
 impl ReplayEngine {
     // Getter methods for atomic execution
     pub fn history_delta(&self) -> &[Event] {
@@ -1825,13 +1870,8 @@ fn update_action_event_id(action: Action, event_id: u64) -> Action {
 }
 
 /// Poll a future once
-fn poll_once<F: Future + ?Sized>(fut: Pin<&mut F>) -> Poll<F::Output> {
-    // Create a no-op waker
-    static VTABLE: RawWakerVTable =
-        RawWakerVTable::new(|_| RawWaker::new(std::ptr::null(), &VTABLE), |_| {}, |_| {}, |_| {});
-    let raw_waker = RawWaker::new(std::ptr::null(), &VTABLE);
-    let waker = unsafe { Waker::from_raw(raw_waker) };
-    let mut cx = Context::from_waker(&waker);
+fn poll_once<F: Future + ?Sized>(fut: Pin<&mut F>, waker: &Waker) -> Poll<F::Output> {
+    let mut cx = Context::from_waker(waker);
     fut.poll(&mut cx)
 }
 

--- a/tests/replay_engine/composition.rs
+++ b/tests/replay_engine/composition.rs
@@ -3,7 +3,39 @@
 //! Tests for aggregate future behavior (select, join).
 
 use super::helpers::*;
+use async_trait::async_trait;
+use duroxide::{OrchestrationContext, OrchestrationHandler};
+use std::sync::Arc;
 use std::time::Duration;
+
+struct LargeSubOrchestrationFanInHandler {
+    count: usize,
+}
+
+impl LargeSubOrchestrationFanInHandler {
+    fn new(count: usize) -> Arc<Self> {
+        Arc::new(Self { count })
+    }
+}
+
+#[async_trait]
+impl OrchestrationHandler for LargeSubOrchestrationFanInHandler {
+    async fn invoke(&self, ctx: OrchestrationContext, _input: String) -> Result<String, String> {
+        let futures = (0..self.count)
+            .map(|idx| ctx.schedule_sub_orchestration_with_id("Child", format!("child-{idx}"), idx.to_string()))
+            .collect::<Vec<_>>();
+
+        let results = ctx.join(futures).await;
+        let completed = results.into_iter().collect::<Result<Vec<_>, _>>()?;
+        for (idx, result) in completed.iter().enumerate() {
+            if result != &idx.to_string() {
+                return Err(format!("result at index {idx} was {result}"));
+            }
+        }
+
+        Ok(completed.len().to_string())
+    }
+}
 
 /// select2 where activity wins (completes before timer).
 ///
@@ -192,4 +224,44 @@ fn join_one_fails() {
 
     // Join collects results, if one fails the combined result is Err
     assert_failed(&result);
+}
+
+/// Large fan-in where every sub-orchestration has completed in history.
+///
+/// This mirrors a production-scale failure mode: parent bulk orchestrations had
+/// all child SubOrchestrationCompleted events persisted, no queue items remained,
+/// but replay did not produce a terminal event for the parent.
+#[test]
+fn join_large_completed_sub_orchestration_fan_in_reaches_terminal() {
+    const FAN_IN_COUNT: usize = 1024;
+
+    let mut history = Vec::with_capacity(1 + FAN_IN_COUNT * 2);
+    history.push(started_event(1));
+
+    for idx in 0..FAN_IN_COUNT {
+        history.push(sub_orch_scheduled(
+            (idx + 2) as u64,
+            "Child",
+            &format!("child-{idx}"),
+            &idx.to_string(),
+        ));
+    }
+
+    for idx in 0..FAN_IN_COUNT {
+        history.push(sub_orch_completed(
+            (FAN_IN_COUNT + idx + 2) as u64,
+            (idx + 2) as u64,
+            &idx.to_string(),
+        ));
+    }
+
+    let mut engine = create_engine(history);
+    let handler = LargeSubOrchestrationFanInHandler::new(FAN_IN_COUNT);
+    let result = execute(&mut engine, handler);
+
+    assert_completed(&result, &FAN_IN_COUNT.to_string());
+    assert!(
+        engine.pending_actions().is_empty(),
+        "fully replayed fan-in should not emit new pending work"
+    );
 }


### PR DESCRIPTION
## Summary

- Add a 1024-way completed sub-orchestration fan-in replay regression test that verifies each joined result.
- Store schedule-to-token bindings so replay completion delivery is O(1) instead of scanning every token binding.
- Replace the replay no-op waker with a private wake state, and register durable-future token wakers so replayed completions can drive wake-based progress.

## Background

This was distilled from a spin loop bug in the wild. Parent bulk orchestrations had very large fan-in, all child `SubOrchestrationCompleted` events were already persisted, and no queue work remained, but replay still failed to produce a terminal parent event.

## Root Cause

There were two related issues.

First, replay polled orchestration futures with a no-op waker. For large inputs, `futures::future::join_all` uses wake-driven readiness internally, so simply polling the parent future again is not enough: completed durable children need to wake the task. Without those wakes, a fully replayed large fan-in can return `Continue` instead of reaching `Completed`.

Second, replay completion delivery only had token-to-schedule bindings, so each completed schedule searched all bound tokens. With large fan-in, that made history replay O(n^2) just to deliver completions.

## Validation

- ./run-tests.sh
- cargo fmt --check
- git diff --check upstream/main...HEAD
