### PR TITLE
Use deterministic combinators for OrchestrationContext::join/select

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["asynchronous", "concurrency"]
 [features]
 default = []
 sqlite = ["sqlx", "libsqlite3-sys"]  # SQLite provider (bundled, no system deps)
-provider-test = []  # Provider validation test harness (generic, no provider dependency)
+provider-test = ["futures"]  # Provider validation test harness (generic, no provider dependency)
 test = ["provider-test", "test-hooks"]  # Auto-enable provider-test and test-hooks for tests
 test-hooks = []  # Enable test hooks for fault injection in integration tests
 replay-version-test = ["test"]  # Zero-cost: only gates test code for replay engine extensibility verification
@@ -22,13 +22,15 @@ replay-version-test = ["test"]  # Zero-cost: only gates test code for replay eng
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"  # For CancellationToken
-futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
 tracing = { version = "0.1", features = ["std"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }
 semver = "1"
+
+# used by provider-tests
+futures = { version = "0.3", optional = true }
 
 # Metrics facade (always on, zero-cost if no recorder installed)
 metrics = "0.24"

--- a/docs/ORCHESTRATION-GUIDE.md
+++ b/docs/ORCHESTRATION-GUIDE.md
@@ -2634,7 +2634,7 @@ async fn fast_updates(ctx: OrchestrationContext, items_json: String) -> Result<(
 
 **Symptom:** Non-deterministic behavior on replay
 
-**Fix:** Use `ctx.select2()` / `ctx.select3()` and `ctx.join()` instead—these use `futures::select_biased!` for determinism
+**Fix:** Use `ctx.select2()` / `ctx.select3()` and `ctx.join()` instead. These use Duroxide's replay-safe combinators for deterministic polling and winner selection.
 
 ---
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -111,7 +111,7 @@ match ctx.select2(activity, timeout).await {
 }
 ```
 
-`select2` uses `futures::select_biased!` internally—the first future to complete wins, and the loser is dropped.
+`select2` polls branches in argument order using Duroxide's local replay-safe select future. The first future to complete wins, and the loser is dropped.
 
 ### Join (Fan-out)
 
@@ -123,7 +123,7 @@ let f3 = ctx.schedule_activity("Task", "C");
 let results = ctx.join(vec![f1, f2, f3]).await;  // Wait for all 3
 ```
 
-`join` uses `futures::future::join_all` internally—all futures run concurrently and results are collected in order.
+`join` polls every pending child future on each replay poll, so large fan-outs remain deterministic even though the replay engine does not rely on child wake notifications. Results are collected in input order.
 
 ### Session Affinity
 

--- a/docs/proposals-impl/replay-simplification-PROGRESS.md
+++ b/docs/proposals-impl/replay-simplification-PROGRESS.md
@@ -78,7 +78,7 @@ All APIs now use clean names without `simplified_` prefix:
 | Area | Behavior |
 |------|----------|
 | `join()` | Returns results in schedule order (not history completion order) |
-| `select2/3()` | Uses `futures::select_biased!` for deterministic winner selection |
+| `select2/3()` | Uses local biased select futures for deterministic winner selection |
 | `trace*()` | Traces are emitted but not stored in history |
 
 ### TBD: Cancellation Wiring (Orchestration → Activities)

--- a/docs/proposals-impl/replay-simplification.md
+++ b/docs/proposals-impl/replay-simplification.md
@@ -127,11 +127,11 @@ One motivation for this replay simplification is enabling orchestrations to expr
 - With this replay model, the only source of progress is history-delivered information (completions/external/cancel). The engine only polls when such information is delivered, making scheduling deterministic.
 
 ### Planned implementation approach
-- `select` combinator: delegate to `futures::select_biased`.
-   - Rationale: deterministic tie-breaking via left-biased polling order.
+- `select` combinator: use Duroxide's local biased select future.
+   - Rationale: deterministic tie-breaking via left-biased polling order without relying on upstream combinator internals.
    - Requirement: operand order must be stable across replays (no data-dependent reordering of branches).
-- `join` combinator: delegate to `futures::join`.
-   - Rationale: deterministic completion after both branches resolve.
+- `join` combinator: use Duroxide's local poll-all join futures.
+   - Rationale: deterministic completion after all branches resolve without relying on child wake notifications.
 
 ### Cancellation semantics interaction
 - For `select` that cancels the loser: Duroxide should deterministically mark the loser branch as cancelled at the orchestration level (to avoid FIFO stalls) and may additionally trigger physical cancellation (best-effort) via `Drop` / provider cancellation.

--- a/docs/proposals-impl/standard-async-futures.md
+++ b/docs/proposals-impl/standard-async-futures.md
@@ -15,18 +15,18 @@ This proposal has been implemented with the following design decisions:
 1. **Token-based scheduling**: `schedule_*()` methods emit actions with tokens that are bound to history event IDs during replay
 2. **Direct await**: `schedule_*()` returns `impl Future` that can be `.await`ed directly (no `.into_activity()` etc.)
 3. **Context-provided combinators**: Instead of raw `futures::select!`/`futures::join!`, orchestrations use:
-   - `ctx.join(futures)` / `ctx.join2(f1, f2)` / `ctx.join3(f1, f2, f3)` 
+    - `ctx.join(futures)` / `ctx.join2(f1, f2)` / `ctx.join3(f1, f2, f3)`
    - `ctx.select2(f1, f2)` / `ctx.select3(f1, f2, f3)`
-   
-   These combinators use `futures::select_biased!` internally for deterministic winner selection.
+
+    These combinators use local replay-safe futures for deterministic winner selection.
 
 4. **FIFO completion ordering**: Completions are delivered in history order to ensure deterministic replay
 
-**Key difference from original proposal:** The original proposal suggested using raw `futures::select!` and `futures::join!` macros directly. The actual implementation provides `ctx.*` wrapper methods that ensure deterministic behavior via `futures::select_biased!` for selects and `futures::join_all` for joins.
+**Key difference from original proposal:** The original proposal suggested using raw `futures::select!` and `futures::join!` macros directly. The actual implementation provides `ctx.*` wrapper methods that ensure deterministic behavior via replay-safe local select and poll-all join implementations.
 
 **Why `ctx.*` combinators instead of raw `futures::*`?**
 - `futures::select!` uses pseudo-random polling order - non-deterministic
-- `ctx.select2/3()` uses `futures::select_biased!` - deterministic (first branch always polled first)
+- `ctx.select2/3()` uses a local biased select future - deterministic (first branch always polled first)
 - This ensures replay produces identical results
 
 See [docs/ORCHESTRATION-GUIDE.md](../docs/ORCHESTRATION-GUIDE.md) for usage examples and [docs/durable-futures-internals.md](../docs/durable-futures-internals.md) for implementation details.

--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -1,0 +1,256 @@
+use crate::{Either2, Either3};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub(crate) struct PollAllJoin<F: Future> {
+    futures: Vec<Option<Pin<Box<F>>>>,
+    outputs: Vec<Option<F::Output>>,
+    remaining: usize,
+}
+
+impl<F: Future> PollAllJoin<F> {
+    pub(crate) fn new(futures: Vec<F>) -> Self {
+        let remaining = futures.len();
+        Self {
+            futures: futures.into_iter().map(|future| Some(Box::pin(future))).collect(),
+            outputs: std::iter::repeat_with(|| None).take(remaining).collect(),
+            remaining,
+        }
+    }
+}
+
+impl<F: Future> Unpin for PollAllJoin<F> {}
+
+impl<F: Future> Future for PollAllJoin<F> {
+    type Output = Vec<F::Output>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+
+        for index in 0..this.futures.len() {
+            if this.futures[index].is_none() {
+                continue;
+            }
+
+            let poll_result = {
+                let future = this.futures[index].as_mut().expect("future slot should be occupied");
+                future.as_mut().poll(cx)
+            };
+
+            if let Poll::Ready(output) = poll_result {
+                this.outputs[index] = Some(output);
+                this.futures[index] = None;
+                this.remaining -= 1;
+            }
+        }
+
+        if this.remaining == 0 {
+            let outputs = std::mem::take(&mut this.outputs)
+                .into_iter()
+                .map(|output| output.expect("completed future should have output"))
+                .collect();
+            Poll::Ready(outputs)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+pub(crate) struct PollAllJoin2<F1: Future, F2: Future> {
+    f1: Option<Pin<Box<F1>>>,
+    f2: Option<Pin<Box<F2>>>,
+    output1: Option<F1::Output>,
+    output2: Option<F2::Output>,
+}
+
+impl<F1: Future, F2: Future> PollAllJoin2<F1, F2> {
+    pub(crate) fn new(f1: F1, f2: F2) -> Self {
+        Self {
+            f1: Some(Box::pin(f1)),
+            f2: Some(Box::pin(f2)),
+            output1: None,
+            output2: None,
+        }
+    }
+}
+
+impl<F1: Future, F2: Future> Unpin for PollAllJoin2<F1, F2> {}
+
+impl<F1: Future, F2: Future> Future for PollAllJoin2<F1, F2> {
+    type Output = (F1::Output, F2::Output);
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+
+        if let Some(future) = &mut this.f1
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            this.output1 = Some(output);
+            this.f1 = None;
+        }
+
+        if let Some(future) = &mut this.f2
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            this.output2 = Some(output);
+            this.f2 = None;
+        }
+
+        if this.f1.is_none() && this.f2.is_none() {
+            Poll::Ready((
+                this.output1.take().expect("completed future should have output"),
+                this.output2.take().expect("completed future should have output"),
+            ))
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+pub(crate) struct PollAllJoin3<F1: Future, F2: Future, F3: Future> {
+    f1: Option<Pin<Box<F1>>>,
+    f2: Option<Pin<Box<F2>>>,
+    f3: Option<Pin<Box<F3>>>,
+    output1: Option<F1::Output>,
+    output2: Option<F2::Output>,
+    output3: Option<F3::Output>,
+}
+
+impl<F1: Future, F2: Future, F3: Future> PollAllJoin3<F1, F2, F3> {
+    pub(crate) fn new(f1: F1, f2: F2, f3: F3) -> Self {
+        Self {
+            f1: Some(Box::pin(f1)),
+            f2: Some(Box::pin(f2)),
+            f3: Some(Box::pin(f3)),
+            output1: None,
+            output2: None,
+            output3: None,
+        }
+    }
+}
+
+impl<F1: Future, F2: Future, F3: Future> Unpin for PollAllJoin3<F1, F2, F3> {}
+
+impl<F1: Future, F2: Future, F3: Future> Future for PollAllJoin3<F1, F2, F3> {
+    type Output = (F1::Output, F2::Output, F3::Output);
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+
+        if let Some(future) = &mut this.f1
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            this.output1 = Some(output);
+            this.f1 = None;
+        }
+
+        if let Some(future) = &mut this.f2
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            this.output2 = Some(output);
+            this.f2 = None;
+        }
+
+        if let Some(future) = &mut this.f3
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            this.output3 = Some(output);
+            this.f3 = None;
+        }
+
+        if this.f1.is_none() && this.f2.is_none() && this.f3.is_none() {
+            Poll::Ready((
+                this.output1.take().expect("completed future should have output"),
+                this.output2.take().expect("completed future should have output"),
+                this.output3.take().expect("completed future should have output"),
+            ))
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+pub(crate) struct Select2<F1: Future, F2: Future> {
+    f1: Option<Pin<Box<F1>>>,
+    f2: Option<Pin<Box<F2>>>,
+}
+
+impl<F1: Future, F2: Future> Select2<F1, F2> {
+    pub(crate) fn new(f1: F1, f2: F2) -> Self {
+        Self {
+            f1: Some(Box::pin(f1)),
+            f2: Some(Box::pin(f2)),
+        }
+    }
+}
+
+impl<F1: Future, F2: Future> Unpin for Select2<F1, F2> {}
+
+impl<F1: Future, F2: Future> Future for Select2<F1, F2> {
+    type Output = Either2<F1::Output, F2::Output>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+
+        if let Some(future) = &mut this.f1
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            return Poll::Ready(Either2::First(output));
+        }
+
+        if let Some(future) = &mut this.f2
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            return Poll::Ready(Either2::Second(output));
+        }
+
+        Poll::Pending
+    }
+}
+
+pub(crate) struct Select3<F1: Future, F2: Future, F3: Future> {
+    f1: Option<Pin<Box<F1>>>,
+    f2: Option<Pin<Box<F2>>>,
+    f3: Option<Pin<Box<F3>>>,
+}
+
+impl<F1: Future, F2: Future, F3: Future> Select3<F1, F2, F3> {
+    pub(crate) fn new(f1: F1, f2: F2, f3: F3) -> Self {
+        Self {
+            f1: Some(Box::pin(f1)),
+            f2: Some(Box::pin(f2)),
+            f3: Some(Box::pin(f3)),
+        }
+    }
+}
+
+impl<F1: Future, F2: Future, F3: Future> Unpin for Select3<F1, F2, F3> {}
+
+impl<F1: Future, F2: Future, F3: Future> Future for Select3<F1, F2, F3> {
+    type Output = Either3<F1::Output, F2::Output, F3::Output>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+
+        if let Some(future) = &mut this.f1
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            return Poll::Ready(Either3::First(output));
+        }
+
+        if let Some(future) = &mut this.f2
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            return Poll::Ready(Either3::Second(output));
+        }
+
+        if let Some(future) = &mut this.f3
+            && let Poll::Ready(output) = future.as_mut().poll(cx)
+        {
+            return Poll::Ready(Either3::Third(output));
+        }
+
+        Poll::Pending
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,6 +810,7 @@ use serde::{Deserialize, Serialize};
 use std::time::{Duration as StdDuration, SystemTime, UNIX_EPOCH};
 
 // Internal codec utilities for typed I/O (kept private; public API remains ergonomic)
+mod combinators;
 mod _typed_codec {
     use serde::{Serialize, de::DeserializeOwned};
     use serde_json::Value;
@@ -3417,7 +3418,7 @@ impl OrchestrationContext {
     }
 }
 
-// Aggregate future machinery lives below (OrchestrationContext helpers)
+// Aggregate future machinery lives in combinators.rs (OrchestrationContext helpers)
 
 impl OrchestrationContext {
     // =========================================================================
@@ -3886,13 +3887,16 @@ impl OrchestrationContext {
             .map(|r| r.and_then(|s| crate::_typed_codec::Json::decode::<Out>(&s)))
     }
 
-    /// Await all futures concurrently using `futures::future::join_all`.
-    /// Works with any `Future` type.
+    /// Await all futures concurrently, polling every pending future on each replay poll.
+    ///
+    /// This intentionally avoids `futures::future::join_all`, which switches large joins to a
+    /// waker-driven implementation. The replay engine drives orchestration futures by polling at
+    /// deterministic history boundaries, so `join` must not rely on child wake notifications.
     pub async fn join<T, F>(&self, futures: Vec<F>) -> Vec<T>
     where
         F: Future<Output = T>,
     {
-        ::futures::future::join_all(futures).await
+        combinators::PollAllJoin::new(futures).await
     }
 
     /// Simplified join for exactly 2 futures (convenience method).
@@ -3901,7 +3905,7 @@ impl OrchestrationContext {
         F1: Future<Output = T1>,
         F2: Future<Output = T2>,
     {
-        ::futures::future::join(f1, f2).await
+        combinators::PollAllJoin2::new(f1, f2).await
     }
 
     /// Simplified join for exactly 3 futures (convenience method).
@@ -3911,14 +3915,14 @@ impl OrchestrationContext {
         F2: Future<Output = T2>,
         F3: Future<Output = T3>,
     {
-        ::futures::future::join3(f1, f2, f3).await
+        combinators::PollAllJoin3::new(f1, f2, f3).await
     }
 
     /// Simplified select over 2 futures: returns the result of whichever completes first.
     /// Select over 2 futures with potentially different output types.
     ///
     /// Returns `Either2::First(result)` if first future wins, `Either2::Second(result)` if second wins.
-    /// Uses futures::select_biased! for determinism (first branch polled first).
+    /// Polls futures in argument order for deterministic biased winner selection.
     ///
     /// # Example: Activity with timeout
     /// ```rust,no_run
@@ -3939,34 +3943,20 @@ impl OrchestrationContext {
         F1: Future<Output = T1>,
         F2: Future<Output = T2>,
     {
-        use ::futures::FutureExt;
-        let mut f1 = std::pin::pin!(f1.fuse());
-        let mut f2 = std::pin::pin!(f2.fuse());
-        ::futures::select_biased! {
-            result = f1 => Either2::First(result),
-            result = f2 => Either2::Second(result),
-        }
+        combinators::Select2::new(f1, f2).await
     }
 
     /// Select over 3 futures with potentially different output types.
     ///
     /// Returns `Either3::First/Second/Third(result)` depending on which future completes first.
-    /// Uses futures::select_biased! for determinism (earlier branches polled first).
+    /// Polls futures in argument order for deterministic biased winner selection.
     pub async fn select3<T1, T2, T3, F1, F2, F3>(&self, f1: F1, f2: F2, f3: F3) -> Either3<T1, T2, T3>
     where
         F1: Future<Output = T1>,
         F2: Future<Output = T2>,
         F3: Future<Output = T3>,
     {
-        use ::futures::FutureExt;
-        let mut f1 = std::pin::pin!(f1.fuse());
-        let mut f2 = std::pin::pin!(f2.fuse());
-        let mut f3 = std::pin::pin!(f3.fuse());
-        ::futures::select_biased! {
-            result = f1 => Either3::First(result),
-            result = f2 => Either3::Second(result),
-            result = f3 => Either3::Third(result),
-        }
+        combinators::Select3::new(f1, f2, f3).await
     }
 }
 

--- a/src/runtime/replay_engine.rs
+++ b/src/runtime/replay_engine.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll};
 use tracing::{debug, warn};
 
 /// Result of executing an orchestration turn
@@ -1827,10 +1827,7 @@ fn update_action_event_id(action: Action, event_id: u64) -> Action {
 /// Poll a future once
 fn poll_once<F: Future + ?Sized>(fut: Pin<&mut F>) -> Poll<F::Output> {
     // Create a no-op waker
-    static VTABLE: RawWakerVTable =
-        RawWakerVTable::new(|_| RawWaker::new(std::ptr::null(), &VTABLE), |_| {}, |_| {}, |_| {});
-    let raw_waker = RawWaker::new(std::ptr::null(), &VTABLE);
-    let waker = unsafe { Waker::from_raw(raw_waker) };
+    let waker = std::task::Waker::noop();
     let mut cx = Context::from_waker(&waker);
     fut.poll(&mut cx)
 }

--- a/tests/replay_engine/composition.rs
+++ b/tests/replay_engine/composition.rs
@@ -3,7 +3,39 @@
 //! Tests for aggregate future behavior (select, join).
 
 use super::helpers::*;
+use async_trait::async_trait;
+use duroxide::{OrchestrationContext, OrchestrationHandler};
+use std::sync::Arc;
 use std::time::Duration;
+
+struct LargeSubOrchestrationFanInHandler {
+    count: usize,
+}
+
+impl LargeSubOrchestrationFanInHandler {
+    fn new(count: usize) -> Arc<Self> {
+        Arc::new(Self { count })
+    }
+}
+
+#[async_trait]
+impl OrchestrationHandler for LargeSubOrchestrationFanInHandler {
+    async fn invoke(&self, ctx: OrchestrationContext, _input: String) -> Result<String, String> {
+        let futures = (0..self.count)
+            .map(|idx| ctx.schedule_sub_orchestration_with_id("Child", format!("child-{idx}"), idx.to_string()))
+            .collect::<Vec<_>>();
+
+        let results = ctx.join(futures).await;
+        let completed = results.into_iter().collect::<Result<Vec<_>, _>>()?;
+        for (idx, result) in completed.iter().enumerate() {
+            if result != &idx.to_string() {
+                return Err(format!("result at index {idx} was {result}"));
+            }
+        }
+
+        Ok(completed.len().to_string())
+    }
+}
 
 /// select2 where activity wins (completes before timer).
 ///
@@ -192,4 +224,44 @@ fn join_one_fails() {
 
     // Join collects results, if one fails the combined result is Err
     assert_failed(&result);
+}
+
+/// Large fan-in where every sub-orchestration has completed in history.
+///
+/// This mirrors a production-scale failure mode: parent bulk orchestrations had
+/// all child SubOrchestrationCompleted events persisted, no queue items remained,
+/// but replay did not produce a terminal event for the parent.
+#[test]
+fn join_large_completed_sub_orchestration_fan_in_reaches_terminal() {
+    const FAN_IN_COUNT: usize = 1024;
+
+    let mut history = Vec::with_capacity(1 + FAN_IN_COUNT * 2);
+    history.push(started_event(1));
+
+    for idx in 0..FAN_IN_COUNT {
+        history.push(sub_orch_scheduled(
+            (idx + 2) as u64,
+            "Child",
+            &format!("child-{idx}"),
+            &idx.to_string(),
+        ));
+    }
+
+    for idx in 0..FAN_IN_COUNT {
+        history.push(sub_orch_completed(
+            (FAN_IN_COUNT + idx + 2) as u64,
+            (idx + 2) as u64,
+            &idx.to_string(),
+        ));
+    }
+
+    let mut engine = create_engine(history);
+    let handler = LargeSubOrchestrationFanInHandler::new(FAN_IN_COUNT);
+    let result = execute(&mut engine, handler);
+
+    assert_completed(&result, &FAN_IN_COUNT.to_string());
+    assert!(
+        engine.pending_actions().is_empty(),
+        "fully replayed fan-in should not emit new pending work"
+    );
 }


### PR DESCRIPTION
Mark Wotton identified the bug that OrchestrationContext::join can fail to complete and provided a regression test in #18.

The root cause of the bug is that futures::future::join_all switches from a "poll all in order" strategy to using FuturesOrdered when the number of futures exceeds a threshold (currently 30 futures). See https://docs.rs/futures/latest/futures/future/fn.join_all.html#see-also.

This PR fixes the bug by replacing futures::future::join_all with a custom combinator, that always polls all pending futures in order, ensuring deterministic ordering.

The join2, join3, select2, and select3 are also updated to use custom combinators. Although currently this is not necessary, it ensures upstream changes to futures crate do not regress duroxide.

Stable Rust now has a noop waker in the standard library, so poll_once is updated to use it, removing `unsafe`.

The futures crate is disabled by default to discourage its use in the duroxide implementation, but still used by provider-test.

This PR incorporates Mark's regression test.