### PR TITLE
docs: add "The Duroxide family" cross-link section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,31 @@ async fn comp_sample(ctx: OrchestrationContext) -> String {
 - Run `cargo run --example metrics_cli` to see observability dashboard
 - See `docs/observability-guide.md` for complete guide
 
+### The Duroxide family
+
+Several related projects share Duroxide's durable-execution model. Pick the
+one that fits how you want to author and host your workflows:
+
+- **[pg_durable](https://github.com/microsoft/pg_durable)** — PostgreSQL
+  extension. Use this when you want durable pipelines and functions
+  **directly in PostgreSQL**, with no other moving parts.
+- **[duroxide](https://github.com/microsoft/duroxide)** _(this repo)_ —
+  Rust durable-execution runtime. Use this when you want to author
+  workflows in **Rust** and embed the runtime in your service. Multiple
+  storage providers are available (SQLite built-in, PostgreSQL via
+  [duroxide-pg](https://github.com/microsoft/duroxide-pg), or bring your
+  own).
+- **[duroxide-python](https://github.com/microsoft/duroxide-python)** —
+  Python SDK over the duroxide runtime. Use this when you want to author
+  workflows in **Python**.
+- **[duroxide-node](https://github.com/microsoft/duroxide-node)** —
+  Node.js / TypeScript SDK over the duroxide runtime. Use this when you
+  want to author workflows in **JavaScript / TypeScript**.
+- **[duroxide-pg](https://github.com/microsoft/duroxide-pg)** — PostgreSQL
+  provider for the duroxide runtime. Plug this into duroxide /
+  duroxide-python / duroxide-node when you want **PostgreSQL** as the
+  durable store.
+
 ### Notes
 - Import as `duroxide` in Rust source.
 - Timers are real time (Tokio sleep). External events are via `Runtime::raise_event`.


### PR DESCRIPTION
Adds a short "The Duroxide family" overview to the hub README. The
section names the related projects (pg_durable, duroxide-pg,
duroxide-python, duroxide-node) and explains the role of each.

### Companion PRs
- microsoft/pg_durable#193 — short `pg_durable` vs. `duroxide-pg` disambiguator
- microsoft/duroxide-pg#12 — symmetric disambiguator on the duroxide-pg side