### PR TITLE
Fix stale project link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ waits 30 days looks exactly like one that waits 30 milliseconds — and if the
 process dies in the middle, it resumes right where it left off, without
 re-running the work it already finished.
 
-Inspired by the [Durable Task Framework](https://github.com/Azure/durabletask)
+Inspired by the [Durable Task Framework](https://aka.ms/durabletask)
 and [Temporal](https://temporal.io/).
 
 ### What you get


### PR DESCRIPTION
The current link is to a repository that can no longer be accessed.

<img width="728" height="349" alt="image" src="https://github.com/user-attachments/assets/ec62807c-0213-428b-9a51-e7e402bd0e0d" />