### PR TITLE
Implement Clone for Client

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -167,6 +167,7 @@ const POLL_DELAY_MULTIPLIER: u64 = 2;
 ///     _ => {}
 /// }
 /// ```
+#[derive(Clone)]
 pub struct Client {
     store: Arc<dyn Provider>,
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -26,6 +26,13 @@ async fn create_test_runtime(activity_registry: ActivityRegistry) -> Arc<runtime
     runtime::Runtime::start(activity_registry, orchestration_registry).await
 }
 
+#[test]
+fn client_is_cloneable_and_thread_safe() {
+    fn assert_traits<T: Clone + Send + Sync>() {}
+
+    assert_traits::<duroxide::Client>();
+}
+
 // 3) Deterministic replay on a tiny flow (activity only)
 #[tokio::test]
 async fn deterministic_replay_activity_only() {


### PR DESCRIPTION
## Summary

Client is documented as cloneable but did not implement Clone. Derive Clone so callers can cheaply duplicate a client while sharing the existing provider through its Arc.

## Checklist

- [x] Tests added/updated
- [x] Regular tests pass locally (`cargo nt`)
- [x] Doc tests pass locally (`cargo test --doc --all-features`)
- [x] Docs updated
  - [x] Existing docs updated where behavior changed
  - [x] New doc added under `docs/` if introducing a new area
  - [x] Linked from `docs/README.md`

## Links / Design notes
N/A