### PR TITLE
docs: externalize crate publishing to Microsoft internal OSS infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 > **[Latest Release: v0.1.30](https://crates.io/crates/duroxide/0.1.30)** — Sub-orchestration parent-link and collision fixes, safer IDs, and UUID generation.
 > See [CHANGELOG.md](CHANGELOG.md#0130---2026-07-29) for release notes.
+>
+> **Releases are published by Microsoft's internal OSS infrastructure.** See [RELEASE_POLICY.md](RELEASE_POLICY.md) for details.
 
 > **Preview:** This project is currently in preview.
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -1,0 +1,79 @@
+# Duroxide Release Policy
+
+## Overview
+
+Duroxide is published to [crates.io](https://crates.io/crates/duroxide) by Microsoft's internal release infrastructure. This document outlines the public release workflow and internal publishing process.
+
+## For Open Source Contributors
+
+### Publishing a Release (Contributor Workflow)
+
+**For external contributors:** Submit a PR that updates the version in `Cargo.toml` and adds a corresponding entry to `CHANGELOG.md`. Microsoft maintainers review and merge the version bump.
+
+**For Microsoft maintainers:** After merging a version bump PR to `main`:
+
+1. Create a **release PR** with:
+   - Updated `Cargo.toml` version
+   - Updated `CHANGELOG.md` (with date and highlights)
+   - Updated `README.md` "Latest Release" section
+   - Verification that all tests pass: `cargo test`, `cargo clippy --all-targets --all-features`, `cargo fmt`
+   - Output of `cargo package --locked` (to verify the package is buildable)
+
+2. After merge to `main`, create a **git tag**:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+3. Microsoft's internal OSS Release pipeline automatically:
+   - Detects the new tag
+   - Validates the crate integrity and authenticity
+   - Publishes to crates.io via a signed, audited internal release process
+   - Creates a GitHub Release with notes linking to the CHANGELOG
+
+**Full release workflow instructions** are in [prompts/duroxide-crate-release.md](prompts/duroxide-crate-release.md).
+
+### What Contributors Should NOT Do
+
+- Do NOT run `cargo publish --locked` yourself
+- Do NOT create GitHub Releases manually (the release pipeline handles this)
+- Do NOT assume crates.io credentials are needed for contributors
+
+## Publishing Infrastructure (Microsoft Internal)
+
+Microsoft maintains an internal OneBranch pipeline that:
+
+- Monitors duroxide git tags matching `v*`
+- Validates the build artifact matches the public source commit
+- Runs compliance checks (SBOM, security scanning)
+- Publishes to crates.io using Microsoft's signed release credentials
+- Creates audit logs and release metadata for compliance
+
+This separation ensures:
+
+1. **Authenticity**: Crates are published by Microsoft's infrastructure, with clear audit trails
+2. **Consistency**: Every release follows the same validated process
+3. **Security**: Publishing credentials are not distributed to contributors
+4. **Compliance**: Internal publishing includes SBOM, SPDX metadata, and security scanning
+
+## Crate Signing & Integrity
+
+**Note:** Rust/crates.io does **not** support cryptographic signatures on published crates. Trust is established via:
+
+- **HTTPS transport security** between your machine and crates.io
+- **crates.io account security** (API token access control)
+- **Cargo.lock** checksums (for reproducible builds in projects that pin crate versions)
+
+The duroxide crate is delivered over HTTPS from crates.io's CDN. Verify the checksum in your `Cargo.lock` matches the expected value if you need bit-for-bit verification.
+
+## Release Schedule & Support
+
+- **Preview Phase**: duroxide is currently in preview (`v0.1.x`)
+- **Semantic Versioning**: We follow semver; breaking changes will increment the minor version until `v1.0.0`
+- **Supported Versions**: Currently only the latest release on crates.io is actively maintained
+
+See [CHANGELOG.md](CHANGELOG.md) for release history and [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
+
+## Questions?
+
+If you have questions about releases, publishing, or the contribution process, please open an issue on GitHub.

--- a/prompts/duroxide-crate-release.md
+++ b/prompts/duroxide-crate-release.md
@@ -55,14 +55,16 @@ Use this prompt when preparing a crates.io release. Run it end-to-end and paste 
    - `cargo package --locked` (verifies package can be built)
    - Inspect `cargo package --list` for unwanted files.
 
-7) **Tag & publish**
+7) **Tag for release**
    - Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
-   - Publish: `cargo publish --locked`
-   - If publish fails, yank tag or release as needed.
+   - ⚠️ **IMPORTANT**: Do NOT run `cargo publish --locked` yourself.
+   - Microsoft's internal OSS release pipeline will automatically detect the tag and handle publishing to crates.io.
+   - See [RELEASE_POLICY.md](../RELEASE_POLICY.md) for how the publishing infrastructure works.
 
-8) **Post-publish**
-   - Create GitHub release notes (link to changelog).
-   - Announce or update docs/examples if needed.
+8) **Post-release**
+   - Monitor for the automatic GitHub Release creation (should appear within ~30 minutes).
+   - If the release pipeline does not complete, contact the duroxide team.
+   - No manual announcement needed; GitHub Release is created automatically.
 
 ## Release Validation Prompt (for Copilot / reviewers)
 Use this condensed prompt to validate a release PR:


### PR DESCRIPTION
This PR documents that duroxide crate publishing is handled by Microsoft's internal OSS release infrastructure, removing the manual \cargo publish\ responsibility from public contributors.

## Changes

- **NEW**: \RELEASE_POLICY.md\ — Complete documentation of the release model, including internal publishing workflow, contributor responsibilities, and crates.io trust model
- **UPDATED**: \prompts/duroxide-crate-release.md\ — Removed manual \cargo publish\ step; points to RELEASE_POLICY.md; updated post-release expectations for automatic GitHub Release creation
- **UPDATED**: \README.md\ — Added one-line notice that releases are published internally with link to RELEASE_POLICY.md

## Why This Change?

- **Clarity**: Removes ambiguity about who publishes duroxide to crates.io
- **Security**: Publishing credentials are not distributed to public contributors
- **Compliance**: Internal pipeline includes SBOM, security scanning, and audit logs
- **Consistency**: Every release follows the same validated process

## For Reviewers

- ✅ No code changes; documentation only
- ✅ No breaking changes to contributor workflow (version bump → merge → tag still works)
- ✅ CI.yml (build/test) continues unchanged
- ✅ Crates.io trust model documented (HTTPS + tokens; no cryptographic signatures)
- ✅ Internal tooling details not exposed

See \RELEASE_POLICY.md\ for full publishing infrastructure context.